### PR TITLE
fix: handle if else case when generating data flow relationship

### DIFF
--- a/src/handler/injection/injectionhandler.py
+++ b/src/handler/injection/injectionhandler.py
@@ -284,7 +284,7 @@ class InjectionHandler:
     
     def appySanitizers(self):
         query = '''
-            MATCH (sanitizer{is_sanitizer: True})-[r:DATA_FLOW_TO|CALL*]->(untainted)
+            MATCH (sanitizer{is_sanitizer: True})-[r:DATA_FLOW_TO]->(untainted)
             SET untainted.is_tainted=False
             REMOVE untainted:Tainted
             RETURN sanitizer, r, untainted

--- a/src/handler/injection/injectionhandler.py
+++ b/src/handler/injection/injectionhandler.py
@@ -47,7 +47,7 @@ class InjectionHandler:
             code = CodeProcessor(self.language, sourceCode)
             root = code.getRootNode()
             if dfs:
-                astRoot = self.converter.createDataFlowTreeDFS(root, codePath)
+                astRoot = self.converter.dfsIterative(root, codePath)
             else:
                 astRoot = self.converter.createDataFlowTree(root, codePath)
             self.insertTreeToNeo4j(astRoot)

--- a/src/handler/injection/injectionhandler.py
+++ b/src/handler/injection/injectionhandler.py
@@ -1,6 +1,6 @@
 from utils.neo4j import Neo4jConnection
 from utils.intermediate_representation.converter import IRConverter
-from utils.intermediate_representation.nodes import ASTNode, DataFlowEdge, ControlFlowEdge
+from utils.intermediate_representation.nodes import IRNode, DataFlowEdge, ControlFlowEdge
 from utils.codehandler import FileHandler, CodeProcessor
 from utils.vulnhandler import VulnerableHandler, Vulnerable
 from datetime import datetime
@@ -90,8 +90,8 @@ class InjectionHandler:
             # astRoot = self.converter.createAstTree(root, codePath)
             # self.converter.addDataFlowEdgesToTree(astRoot)
     
-    def insertTreeToNeo4j(self, root: ASTNode):
-        queue: list[ASTNode] = [root]
+    def insertTreeToNeo4j(self, root: IRNode):
+        queue: list[IRNode] = [root]
 
         while len(queue) != 0:
             node = queue.pop(0)
@@ -102,8 +102,8 @@ class InjectionHandler:
             for child in node.astChildren:
                 queue.append(child)
 
-    def insertRelationshipsToNeo4j(self, root: ASTNode):
-        queue: list[ASTNode] = [root]
+    def insertRelationshipsToNeo4j(self, root: IRNode):
+        queue: list[IRNode] = [root]
 
         while len(queue) != 0:
             node = queue.pop(0)
@@ -114,7 +114,7 @@ class InjectionHandler:
             for child in node.astChildren:
                 queue.append(child)
         
-    def insertNodeToNeo4j(self, node: ASTNode):
+    def insertNodeToNeo4j(self, node: IRNode):
         parameters = {
             "id": node.id,
             "type": node.type,
@@ -161,7 +161,7 @@ class InjectionHandler:
         except Exception as e:
             print(f"Query create AST relationship error: {e}")
 
-    def createControlFlowRelationship(self, node: ASTNode):
+    def createControlFlowRelationship(self, node: IRNode):
         for edge in node.controlFlowEdges:
             parameters = {
                 "id": node.id,
@@ -182,7 +182,7 @@ class InjectionHandler:
             except Exception as e:
                 print(f"Query create control flow relationship error: {e}")
 
-    def createDataFlowRelationship(self, node: ASTNode):
+    def createDataFlowRelationship(self, node: IRNode):
         for edge in node.dataFlowEdges:
             parameters = {
                     "id": node.id,

--- a/src/testcase/graph/if_else.py
+++ b/src/testcase/graph/if_else.py
@@ -1,11 +1,13 @@
-test = "test value"
+test = "test"
 
-if test == "test value":
-    print("success")
+if test == "test":
+    print(test)
+    test = "uhuy"
+elif test == "test":
+    print(test)
+    test = "ahay"
 else:
-    print("failed")
+    print(test)
+    test = "asoy"
 
-if test in "here":
-    print("here")
-else:
-    print("not here")
+print(test)

--- a/src/testcase/injection/taint_analysis/taint_analysis.py
+++ b/src/testcase/injection/taint_analysis/taint_analysis.py
@@ -1,10 +1,18 @@
-test = input()
+import shlex
+import subprocess
 
-another_test = test
+address = input()
+command = "ping -c 1 {}".format(address)
 
-test = "change test"
+real_command = command
+command = "google.com"
 
 # safe
-eval(test)
-# vulnerable
-eval(another_test)
+subprocess.Popen(command, shell=True)
+
+# vuln
+subprocess.Popen(real_command, shell=True)
+
+# safe
+args = shlex.split(real_command)
+subprocess.Popen(args, shell=True)

--- a/src/utils/constant/intermediate_representation.py
+++ b/src/utils/constant/intermediate_representation.py
@@ -1,0 +1,2 @@
+PYTHON_CONTROL_SCOPE_IDENTIFIERS = ("block", "elif_clause", "else_clause")
+PYTHON_DATA_SCOPE_IDENTIFIERS = ("class_definition", "function_definition")

--- a/src/utils/intermediate_representation/converter.py
+++ b/src/utils/intermediate_representation/converter.py
@@ -251,7 +251,6 @@ class IRConverter():
                 node.astChildren.append(irChild)
                 self.dfs(irChild, visited, symbolTable, scope)
 
-
     def setNodeDataFlowEdges(self, node: IRNode, symbolTable):
         # handle variable assignment and reassignment
             if node.type == "identifier" and node.parent.type == "assignment":

--- a/src/utils/intermediate_representation/converter.py
+++ b/src/utils/intermediate_representation/converter.py
@@ -80,7 +80,7 @@ class IRConverter():
                 currNode.addControlFlowEdge(statementOrder, cfgParentId)
 
             # handle if statement
-            if currNode.type == "if_statement" or currNode.type == "else_clause":
+            if currNode.type == "if_statement" or currNode.type == "else_clause" or currNode.type == "elif_clause":
                 for child in currNode.astChildren:
                     if child.type == "block":
                         blockNode = child
@@ -90,7 +90,7 @@ class IRConverter():
                                 # !!!: depends on lower node
                                 blockNode.astChildren[0].addControlFlowEdge(1, currNode.id)
                             # connect else statements with if statement
-                            elif currNode.type == "else_clause":
+                            elif currNode.type == "else_clause" or currNode.type == "elif_clause":
                                 # !!!: depends on lower node
                                 blockNode.astChildren[0].addControlFlowEdge(1, currNode.parentId)
             

--- a/src/utils/intermediate_representation/converter.py
+++ b/src/utils/intermediate_representation/converter.py
@@ -9,6 +9,19 @@ class IRConverter():
         self.sinks = sinks
         self.sanitizers = sanitizers
 
+    def createCompleteTreeDFS(self, root: Node, filename: str) -> IRNode:
+        irRoot = self.createDataFlowTreeDFS(root, filename)
+        self.addControlFlowEdgesToTree(irRoot)
+
+        return irRoot
+    
+    def createCompleteTree(self, root: Node, filename: str) -> IRNode:
+        irRoot = self.createAstTree(root, filename)
+        self.addControlFlowEdgesToTree(irRoot)
+        self.addDataFlowEdgesToTree(irRoot)
+
+        return irRoot
+
     def createAstTree(self, root: Node, filename: str) -> IRNode:
         # iterate through root until the end using BFS
         # create new AST node for each tree-sitter node
@@ -177,13 +190,6 @@ class IRConverter():
             
             for child in currNode.astChildren:
                 queue.append((child, scope))
-
-    def createCompleteTree(self, root: Node, filename: str) -> IRNode:
-        irRoot = self.createAstTree(root, filename)
-        self.addControlFlowEdgesToTree(irRoot)
-        self.addDataFlowEdgesToTree(irRoot)
-
-        return irRoot
     
     def createDataFlowTree(self, root: Node, filename: str) -> IRNode:
         # iterate through root until the end using BFS
@@ -216,12 +222,6 @@ class IRConverter():
 
             for child in node.children:
                 queue.append((child, convertedNode, scope))
-
-        return irRoot
-    
-    def createCompleteTreeDFS(self, root: Node, filename: str) -> IRNode:
-        irRoot = self.createDataFlowTreeDFS(root, filename)
-        self.addControlFlowEdgesToTree(irRoot)
 
         return irRoot
     

--- a/src/utils/intermediate_representation/exporter.py
+++ b/src/utils/intermediate_representation/exporter.py
@@ -1,0 +1,113 @@
+from pathlib import Path
+import csv
+from utils.intermediate_representation.nodes import IRNode
+
+class IRExporter():
+    def __init__(self) -> None:
+        pass
+    
+    def exportTreeToCsvFiles(self, root: IRNode, exportPath: str):
+        self.exportAstNodesToCsv(root, exportPath)
+        self.exportDfgEdgesToCsv(root, exportPath)
+        self.exportCfgEdgesToCsv(root, exportPath)
+    
+    def exportAstNodesToCsv(self, root: IRNode, exportPath: str):
+        header = [
+                'id', 
+                'type', 
+                'content', 
+                'parent_id', 
+                'scope', 
+                'start_point',
+                'end_point',
+                'is_source', 
+                'is_sink', 
+                'is_tainted',
+                'is_sanitizer',
+                ]
+        
+        # setup file and folder
+        basename = self.getExportBasename(exportPath)
+        Path(f"./csv/{basename}").mkdir(parents=True, exist_ok=True)
+
+        with open(f'./csv/{basename}/{basename}_nodes.csv', 'a', encoding='utf-8') as f:
+            writer = csv.writer(f)
+            writer.writerow(header)
+
+            queue: list[IRNode] = [root]
+
+            while queue:
+                node = queue.pop(0)
+
+                row = [
+                    node.id, 
+                    node.type, 
+                    node.content, 
+                    node.parentId, 
+                    node.scope, 
+                    node.startPoint,
+                    node.endPoint,
+                    node.isSource,
+                    node.isSink,
+                    node.isTainted,
+                    node.isSanitizer,
+                    ]
+                writer.writerow(row)
+
+                for child in node.astChildren:
+                    queue.append(child)
+    
+    def exportDfgEdgesToCsv(self, root: IRNode, exportPath: str):
+        header = ['id', 'dfg_parent_id', 'data_type']
+
+        # setup file and folder
+        basename = self.getExportBasename(exportPath)
+        Path(f"./csv/{basename}").mkdir(parents=True, exist_ok=True)
+
+        with open(f'./csv/{basename}/{basename}_dfg_edges.csv', 'a', encoding='utf-8') as f:
+            writer = csv.writer(f)
+            writer.writerow(header)
+
+            queue: list[IRNode] = [root]
+
+            while queue:
+                node = queue.pop(0)
+
+                for edge in node.dataFlowEdges:
+                    row = [node.id, edge.dfgParentId, edge.dataType]
+                    writer.writerow(row)
+
+                for child in node.astChildren:
+                    queue.append(child)
+    
+    def exportCfgEdgesToCsv(self, root: IRNode, exportPath: str):
+        header = ['id', 'cfg_parent_id', 'statement_order']
+
+        # setup file and folder
+        basename = self.getExportBasename(exportPath)
+        Path(f"./csv/{basename}").mkdir(parents=True, exist_ok=True)
+
+        with open(f'./csv/{basename}/{basename}_cfg_edges.csv', 'a', encoding='utf-8') as f:
+            writer = csv.writer(f)
+            writer.writerow(header)
+
+            queue: list[IRNode] = [root]
+
+            while queue:
+                node = queue.pop(0)
+
+                for edge in node.controlFlowEdges:
+                    row = [node.id, edge.cfgParentId, edge.statementOrder]
+                    writer.writerow(row)
+
+                for child in node.astChildren:
+                    queue.append(child)
+
+    def getExportBasename(self, filename: str) -> str:
+        if len(filename.split("\\")) >= 2:
+            basename = filename.split("\\")[-1].replace("/", "-").replace("\\", "-")
+            if basename[0] == "-":
+                basename = basename[1:]
+        
+            return basename
+        return filename

--- a/src/utils/intermediate_representation/nodes.py
+++ b/src/utils/intermediate_representation/nodes.py
@@ -5,47 +5,43 @@ from typing import Union
 # all node from tree-sitter parse result
 class IRNode:
     def __init__(self, node: Node, filename: str, projectId: str, parent=None) -> None:
-        if self.isIgnoredType(node):
-          self.id = None
-          return
-        else:
-          self.id = uuid.uuid4().hex
-          self.controlFlowEdges: list[ControlFlowEdge] = []
-          self.dataFlowEdges: list[DataFlowEdge] = []
+      self.id = uuid.uuid4().hex
+      self.controlFlowEdges: list[ControlFlowEdge] = []
+      self.dataFlowEdges: list[DataFlowEdge] = []
 
-          # get info from tree-sitter node
-          self.treeSitterId = node.id
-          self.content = node.text.decode("utf-8")
-          self.type = node.type
-          self.node = node
-          self.startPoint = node.start_point
-          self.endPoint = node.end_point
-          self.astChildren: list[IRNode] = []
+      # get info from tree-sitter node
+      self.treeSitterId = node.id
+      self.content = node.text.decode("utf-8")
+      self.type = node.type
+      self.node = node
+      self.startPoint = node.start_point
+      self.endPoint = node.end_point
+      self.astChildren: list[IRNode] = []
 
-          # metadata info
-          self.filename = filename
-          self.projectId = projectId
+      # metadata info
+      self.filename = filename
+      self.projectId = projectId
 
-          # data flow props
-          self.scope = None
-          self.isSource = False
-          self.isSink = False
-          self.isTainted = False
-          self.isSanitizer = False
+      # data flow props
+      self.scope = None
+      self.isSource = False
+      self.isSink = False
+      self.isTainted = False
+      self.isSanitizer = False
 
-          # control flow props
+      # control flow props
 
-          # if root
-          if type(parent) is IRNode:
-            self.parent = parent
-            self.parentId = parent.id
-          else:
-            self.parent = None
-            self.parentId = None
-            self.scope = filename
-            self.isSource = False
-            self.isSink = False
-            self.isTainted = False
+      # if root
+      if type(parent) is IRNode:
+        self.parent = parent
+        self.parentId = parent.id
+      else:
+        self.parent = None
+        self.parentId = None
+        self.scope = filename
+        self.isSource = False
+        self.isSink = False
+        self.isTainted = False
     
     # print shortcut
     def __str__(self) -> str:
@@ -54,7 +50,7 @@ class IRNode:
     def printChildren(self, depth=0):
       indent = ' ' * depth
 
-      print(f'{indent}{self}')
+      print(f'{indent}[{depth}]{self}')
       # control flow info
       # for control in node.controlFlowEdges:
       #     print(f'{indent}[control] {control.cfgParentId} - {control.statementOrder}')
@@ -94,20 +90,25 @@ class IRNode:
         self.dataFlowEdges.append(edge)
 
     def checkIsSource(self, sources) -> bool:
+        if self.parent == None: return False
         for source in sources:
             if source in self.content.lower():
                 return True
         return False
     
     def checkIsSink(self, sinks) -> bool:
+        if self.parent == None: return False
         for sink in sinks:
             if sink in self.content.lower():
                 return True
         return False
     
     def checkIsSanitizer(self, sanitizers) -> bool:
+        if self.parent == None: return False
         for sanitizer in sanitizers:
             if sanitizer in self.content.lower():
+                print(sanitizer)
+                print(self.content.lower())
                 return True
         return False
 

--- a/src/utils/intermediate_representation/nodes.py
+++ b/src/utils/intermediate_representation/nodes.py
@@ -3,7 +3,7 @@ import uuid
 from typing import Union
 
 # all node from tree-sitter parse result
-class ASTNode:
+class IRNode:
     def __init__(self, node: Node, filename: str, projectId: str, parent=None) -> None:
         if self.isIgnoredType(node):
           self.id = None
@@ -20,7 +20,7 @@ class ASTNode:
           self.node = node
           self.startPoint = node.start_point
           self.endPoint = node.end_point
-          self.astChildren: list[ASTNode] = []
+          self.astChildren: list[IRNode] = []
 
           # metadata info
           self.filename = filename
@@ -36,7 +36,7 @@ class ASTNode:
           # control flow props
 
           # if root
-          if type(parent) is ASTNode:
+          if type(parent) is IRNode:
             self.parent = parent
             self.parentId = parent.id
           else:
@@ -80,9 +80,9 @@ class ASTNode:
       return False
     
     def setDataFlowProps(self, scope, sources, sinks, sanitizers):
-      self.isSource = self.checkSource(sources)
-      self.isSink = self.checkSink(sinks)
-      self.isSanitizer = self.checkSanitizer(sanitizers)
+      self.isSource = self.checkIsSource(sources)
+      self.isSink = self.checkIsSink(sinks)
+      self.isSanitizer = self.checkIsSanitizer(sanitizers)
       self.scope = scope
     
     def addControlFlowEdge(self, statementOrder: int, cfgParentId: Union[str, None]):
@@ -93,19 +93,19 @@ class ASTNode:
         edge = DataFlowEdge(dataType, dfgParentId)
         self.dataFlowEdges.append(edge)
 
-    def checkSource(self, sources) -> bool:
+    def checkIsSource(self, sources) -> bool:
         for source in sources:
             if source in self.content.lower():
                 return True
         return False
     
-    def checkSink(self, sinks) -> bool:
+    def checkIsSink(self, sinks) -> bool:
         for sink in sinks:
             if sink in self.content.lower():
                 return True
         return False
     
-    def checkSanitizer(self, sanitizers) -> bool:
+    def checkIsSanitizer(self, sanitizers) -> bool:
         for sanitizer in sanitizers:
             if sanitizer in self.content.lower():
                 return True

--- a/src/utils/intermediate_representation/nodes.py
+++ b/src/utils/intermediate_representation/nodes.py
@@ -5,7 +5,7 @@ from typing import Union
 
 # all node from tree-sitter parse result
 class IRNode:
-    def __init__(self, node: Node, filename: str, projectId: str, controlId: str=None, parent=None) -> None:
+    def __init__(self, node: Node, filename: str, projectId: str, controlId=None, parent=None) -> None:
       self.id = uuid.uuid4().hex
       self.controlFlowEdges: list[ControlFlowEdge] = []
       self.dataFlowEdges: list[DataFlowEdge] = []
@@ -29,7 +29,7 @@ class IRNode:
       self.isSink = False
       self.isTainted = False
       self.isSanitizer = False
-      
+
       if controlId != None:
           self.controlId = controlId
       else:
@@ -82,7 +82,7 @@ class IRNode:
       return False
     
     def isInsideIfElseBranch(self) -> bool:
-        return len(self.scope.rpartition("\\")[2]) > 32 and self.scope.rpartition("\\")[2][:-32] in PYTHON_CONTROL_SCOPE_IDENTIFIERS
+        return self.scope != None and len(self.scope.rpartition("\\")[2]) > 32 and self.scope.rpartition("\\")[2][:-32] in PYTHON_CONTROL_SCOPE_IDENTIFIERS
     
     def setDataFlowProps(self, scope, sources, sinks, sanitizers):
       self.isSource = self.checkIsSource(sources)

--- a/src/utils/intermediate_representation/nodes.py
+++ b/src/utils/intermediate_representation/nodes.py
@@ -5,7 +5,7 @@ from typing import Union
 
 # all node from tree-sitter parse result
 class IRNode:
-    def __init__(self, node: Node, filename: str, projectId: str, parent=None) -> None:
+    def __init__(self, node: Node, filename: str, projectId: str, controlId: str=None, parent=None) -> None:
       self.id = uuid.uuid4().hex
       self.controlFlowEdges: list[ControlFlowEdge] = []
       self.dataFlowEdges: list[DataFlowEdge] = []
@@ -29,6 +29,11 @@ class IRNode:
       self.isSink = False
       self.isTainted = False
       self.isSanitizer = False
+      
+      if controlId != None:
+          self.controlId = controlId
+      else:
+          self.controlId = None
 
       # control flow props
 
@@ -77,10 +82,7 @@ class IRNode:
       return False
     
     def isInsideIfElseBranch(self) -> bool:
-        scopeIdentifiers = PYTHON_CONTROL_SCOPE_IDENTIFIERS
-        lastScope = self.scope.split("\\")[-1]
-
-        return lastScope in scopeIdentifiers
+        return len(self.scope.rpartition("\\")[2]) > 32 and self.scope.rpartition("\\")[2][:-32] in PYTHON_CONTROL_SCOPE_IDENTIFIERS
     
     def setDataFlowProps(self, scope, sources, sinks, sanitizers):
       self.isSource = self.checkIsSource(sources)

--- a/src/utils/intermediate_representation/nodes.py
+++ b/src/utils/intermediate_representation/nodes.py
@@ -1,5 +1,6 @@
 from tree_sitter import Node
 import uuid
+from utils.constant.intermediate_representation import PYTHON_CONTROL_SCOPE_IDENTIFIERS
 from typing import Union
 
 # all node from tree-sitter parse result
@@ -50,7 +51,7 @@ class IRNode:
     def printChildren(self, depth=0):
       indent = ' ' * depth
 
-      print(f'{indent}[{depth}]{self}')
+      print(f'{indent}{self}')
       # control flow info
       # for control in node.controlFlowEdges:
       #     print(f'{indent}[control] {control.cfgParentId} - {control.statementOrder}')
@@ -74,6 +75,12 @@ class IRNode:
         return True
       
       return False
+    
+    def isInsideIfElseBranch(self) -> bool:
+        scopeIdentifiers = PYTHON_CONTROL_SCOPE_IDENTIFIERS
+        lastScope = self.scope.split("\\")[-1]
+
+        return lastScope in scopeIdentifiers
     
     def setDataFlowProps(self, scope, sources, sinks, sanitizers):
       self.isSource = self.checkIsSource(sources)


### PR DESCRIPTION
Changelog:
* Add DFS toggle when creating a tree
* Use iterative DFS to proactively avoid recursive problems (max limit of recursions)
* Able to connect from outside if-else branch to inside if-else branch and vice versa
* Able to connect from inside if-else branch to another inside if-else branch (due to Python scoping where there isn't a scope to an if statement)
* If statements have unique ids (could be made redundant with cfg)